### PR TITLE
Update CloudWatch Logs integration cookbook

### DIFF
--- a/opsworks_cloudwatchlogs/attributes/default.rb
+++ b/opsworks_cloudwatchlogs/attributes/default.rb
@@ -1,12 +1,15 @@
-if node["platform"] == "amazon"
-  default["cloudwatchlogs"]["config_file"] = "/etc/awslogs/awslogs.conf" # Configures the logs for the agent to ship
-  default["cloudwatchlogs"]["home_dir"] = "/etc/awslogs" # Contains configuration files
-  default["cloudwatchlogs"]["state_file"] = "/var/lib/awslogs/agent-state" # See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/QuickStartChef.html
-else
-  default["cloudwatchlogs"]["config_file"] = "/opt/aws/cloudwatch/cwlogs.cfg" # Configures the logs to ship, used by installation script
-  default["cloudwatchlogs"]["home_dir"] = "/var/awslogs" # Contains the awslogs package
-  default["cloudwatchlogs"]["state_file"] = "/var/awslogs/state/agent-state" # See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/QuickStartChef.html
-end
+default["cloudwatchlogs"]["config_file"] = "/opt/aws/cloudwatch/cwlogs.cfg"
+default["cloudwatchlogs"]["home_dir"] = "/opt/aws/cloudwatch"
+default["cloudwatchlogs"]["state_file_dir"] = "/var/awslogs/state"
 
-default["cloudwatchlogs"]["AGENT_LOGS"] = "/var/log/aws/opsworks/*.log"
-default["cloudwatchlogs"]["CHEF_LOGS"] = "/var/lib/aws/opsworks/chef/*.log"
+hostname = node["opsworks"]["instance"]["hostname"]
+instance_layers = node["opsworks"]["instance"]["layers"]
+
+# Collect log_streams from all layers that the instance is attached to
+# Set the default log_stream_name to be the opsworks instance id
+default["cloudwatchlogs"]["log_streams"] = instance_layers.map do |layer_name|
+  cloud_watch_logs_configuration = node["opsworks"]["layers"][layer_name].fetch("cloud_watch_logs_configuration", {})
+  enabled = cloud_watch_logs_configuration["enabled"]
+  log_streams = cloud_watch_logs_configuration["log_streams"]
+  log_streams.map { |stream| { "log_stream_name" => hostname }.merge(stream) } unless log_streams.nil? || !enabled
+end.compact.flatten

--- a/opsworks_cloudwatchlogs/recipes/default.rb
+++ b/opsworks_cloudwatchlogs/recipes/default.rb
@@ -1,4 +1,4 @@
-if node["opsworks"]["log_streams"].any?
+if node["opsworks"]["log_streams"] && node["opsworks"]["log_streams"].any?
   include_recipe "opsworks_cloudwatchlogs::install"
 else
   include_recipe "opsworks_cloudwatchlogs::uninstall" if File.exists?(File.join(node["cloudwatchlogs"]["home_dir"], "INSTALLED_BY_OPSWORKS"))

--- a/opsworks_cloudwatchlogs/recipes/default.rb
+++ b/opsworks_cloudwatchlogs/recipes/default.rb
@@ -1,5 +1,5 @@
-if node["opsworks"]["cloud_watch_logs_configurations"].any?
+if node["opsworks"]["log_streams"].any?
   include_recipe "opsworks_cloudwatchlogs::install"
 else
-  include_recipe "opsworks_cloudwatchlogs::uninstall"
+  include_recipe "opsworks_cloudwatchlogs::uninstall" if File.exists?(File.join(node["cloudwatchlogs"]["home_dir"], "INSTALLED_BY_OPSWORKS"))
 end

--- a/opsworks_cloudwatchlogs/recipes/install.rb
+++ b/opsworks_cloudwatchlogs/recipes/install.rb
@@ -1,49 +1,39 @@
-directory node["cloudwatchlogs"]["home_dir"] do
-  recursive true
+[node["cloudwatchlogs"]["home_dir"], node["cloudwatchlogs"]["state_file_dir"]].each do |dir|
+  directory dir do
+    recursive true
+  end
 end
 
 template node["cloudwatchlogs"]["config_file"] do
   source "awslogs.conf.erb"
   variables({
-    :state_file => node["cloudwatchlogs"]["state_file"],
-    :cloudwatchlogs => node["opsworks"]["cloud_watch_logs_configurations"],
-    :hostname => node["opsworks"]["instance"]["hostname"]
+    :state_file_dir => node["cloudwatchlogs"]["state_file_dir"],
+    :log_streams => node["cloudwatchlogs"]["log_streams"]
   })
   owner "root"
   group "root"
   mode 0644
 end
 
-if platform?("amazon")
-  package "awslogs" do
-    retries 3
-    retry_delay 5
-  end
+remote_file "/opt/aws/cloudwatch/awslogs-agent-setup.py" do
+  source "https://aws-cloudwatch.s3.amazonaws.com/downloads/latest/awslogs-agent-setup.py"
+  mode 0700
+  retries 3
+  retry_delay 5
+end
 
-  template "#{node['cloudwatchlogs']['home_dir']}/awscli.conf" do
-    source "awscli.conf.erb"
-    variables :region => node["opsworks"]["instance"]["region"]
-  end
-else
-  directory "/opt/aws/cloudwatch" do
-    recursive true
-  end
+package "python" do
+  retries 3
+  retry_delay 5
+end
 
-  remote_file "/opt/aws/cloudwatch/awslogs-agent-setup.py" do
-    source "https://aws-cloudwatch.s3.amazonaws.com/downloads/latest/awslogs-agent-setup.py"
-    mode 0700
-    retries 3
-  end
+execute "Install CloudWatch Logs agent" do
+  command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r '#{node['opsworks']['instance']['region']}' -c '#{node['cloudwatchlogs']['config_file']}'"
+  creates File.join(node["cloudwatchlogs"]["state_file_dir"], "state_file")
+end
 
-  package "python" do
-    retries 3
-    retry_delay 5
-  end
-
-  execute "Install CloudWatch Logs agent" do
-    command "/opt/aws/cloudwatch/awslogs-agent-setup.py -n -r '#{node['opsworks']['instance']['region']}' -c '#{node['cloudwatchlogs']['config_file']}'"
-    not_if { File.exists?(node["cloudwatchlogs"]["state_file"]) }
-  end
+file File.join(node["cloudwatchlogs"]["home_dir"], "INSTALLED_BY_OPSWORKS") do
+  content "CloudWatch Logs agent was installed by OpsWorks. Do not delete this file."
 end
 
 service "awslogs" do

--- a/opsworks_cloudwatchlogs/recipes/uninstall.rb
+++ b/opsworks_cloudwatchlogs/recipes/uninstall.rb
@@ -2,22 +2,13 @@ service "awslogs" do
   action :stop
 end
 
-directory node["cloudwatchlogs"]["home_dir"] do
-  action :delete
-  recursive true
-end
-
-if platform?("amazon")
-  package "awslogs" do
-    action :remove
-  end
-else
-  directory "/opt/aws/cloudwatch" do
+[node["cloudwatchlogs"]["home_dir"], node["cloudwatchlogs"]["state_file_dir"]].each do |dir|
+  directory dir do
     action :delete
     recursive true
   end
+end
 
-  file "/etc/init.d/awslogs" do
-    action :delete
-  end
+file "/etc/init.d/awslogs" do
+  action :delete
 end

--- a/opsworks_cloudwatchlogs/templates/default/awscli.conf.erb
+++ b/opsworks_cloudwatchlogs/templates/default/awscli.conf.erb
@@ -1,4 +1,0 @@
-[plugins]
-cwlogs = cwlogs
-[default]
-region = <%= @region %>

--- a/opsworks_cloudwatchlogs/templates/default/awslogs.conf.erb
+++ b/opsworks_cloudwatchlogs/templates/default/awslogs.conf.erb
@@ -1,21 +1,10 @@
 [general]
-state_file = <%= @state_file %>
-
-<% @cloudwatchlogs.each do |log_group_name, log_streams| %>
-<% log_streams.each do |log| %>
-<% if log["file"] == "AGENT"
-  log_path = node["cloudwatchlogs"]["AGENT_LOGS"]
-elsif log["file"] == "CHEF"
-  log_path = node["cloudwatchlogs"]["CHEF_LOGS"]
-else
-  log_path = log["file"]
-end %>
-[<%= log_group_name %> <%= log_path %>]
-datetime_format = [%Y-%m-%d %H:%M:%S]
-log_group_name = <%= log_group_name %>
-log_stream_name = <%= @hostname %> - <%= log_path %>
-initial_position = start_of_file
-file = <%= log_path %>
-
+state_file = <%= @state_file_dir %>/agent-state
+  
+<% @log_streams.each do |log_stream| %>
+[<%= log_stream[:log_group_name] %> <%= log_stream[:file] %>]
+<% log_stream.each do |key, value| %>
+<% next if value.nil? %>
+<%= key %> = <%= value %>
 <% end %>
 <% end %>

--- a/opsworks_custom_dot_env/README.md
+++ b/opsworks_custom_dot_env/README.md
@@ -1,0 +1,45 @@
+To use custom environment variables in Opsworks follow the guide below:
+===================
+
+This cookbook allows Rails apps on [Amazon OpsWorks](http://aws.amazon.com/opsworks/) to separate their configuration from their code. In keeping with [The twelve-factor app](http://www.12factor.net/config), the configuration is made available to the app's environment.
+
+To accomplish this, the cookbook maintains a `.env` file in each respective app's deploy directory. E.g.:
+
+    ---
+    SECRET_KEY_BASE=xxxxxxxxxxxxx
+    DB_PASSWORD=123456789
+
+The application can then load its settings directly from this file, or use [Figaro](https://github.com/laserlemon/figaro) to automatically make these settings available in the app's `ENV` (strong recommended).
+
+Configuration values are specified in the Amazon console but also a [stack's custom JSON](http://docs.aws.amazon.com/opsworks/latest/userguide/workingstacks-json.html) can be passed.
+
+Example of the JSON that we have to pass in the AWS OpsWorks Portal inside: Stack -> Stack Settings -> Edit -> Custom JSON (in Advanced options section).
+
+    {  
+      "deploy": {˙
+        "app_name": {
+          "symlink_before_migrate": {
+            "config/.env": ".env"
+          }
+        }
+      }
+    }
+
+Today we do not need to pass env variables using this JSON. We can only declare env variables in the AWS OpsWorks Portal, inside: Apps -> edit (app_name) -> Environment Variables.
+
+**Note** that the `symlink_before_migrate` attribute is necessary so that OpsWorks automatically symlinks the shared file when setting up release directories or deploying a new version.
+
+
+Caveats
+-------
+
+At the moment, only default Opsworks configurations for Apache/Passenger and Unicorn/Nginx style Rails apps are supported.
+
+
+Opsworks Set-Up
+---------------
+
+* Add `custom_env` and `symlink_before_migrate` attributes to the stack's custom JSON as in the example above.
+* Associate the `opsworks-cookbook-custom-dot-env::custom_env` recipe with the **Deploy** and **Setup** events in your rails app's layer.
+
+A deploy isn't necessary if you just want to update the custom configuration. Instead, update the stack's custom JSON, then choose to _Run Command_ > _execute recipes_ and enter `opsworks_custom_dot_env::configure` into the _Recipes to execute_ field. Executing the recipe will write an updated `.env` file and restart unicorn workers.

--- a/opsworks_custom_dot_env/definitions/custom_env_template.rb
+++ b/opsworks_custom_dot_env/definitions/custom_env_template.rb
@@ -1,0 +1,18 @@
+# Accepts:
+#   application (application name)
+#   deploy (hash of deploy attributes)
+#   env (hash of custom environment settings)
+
+define :custom_env_template do
+  template "#{params[:deploy][:deploy_to]}/shared/config/.env" do
+    source ".env.erb"
+    owner params[:deploy][:user]
+    group params[:deploy][:group]
+    mode "0660"
+    variables :env => params[:env]
+
+    only_if do
+      File.exists?("#{params[:deploy][:deploy_to]}/shared/config")
+    end
+  end
+end

--- a/opsworks_custom_dot_env/metadata.rb
+++ b/opsworks_custom_dot_env/metadata.rb
@@ -1,0 +1,5 @@
+name        "opsworks_custom_dot_env"
+maintainer  "John Doe"
+description "This recipe allow you to use environment variables inside your Rails app when you use a AWS OpsWorks stack."
+
+recipe "opsworks_custom_env::default", "Generate a .env file to contain all environment variables"

--- a/opsworks_custom_dot_env/recipes/default.rb
+++ b/opsworks_custom_dot_env/recipes/default.rb
@@ -1,0 +1,13 @@
+# Recipe used for a setup and deploy events
+Chef::Log.info("Create .env file...")
+
+application = node[:rails][:application_name]
+deploy = node[:deploy][application]
+
+environment_variables = deploy[:custom_env].to_h.merge(deploy[:environment_variables].to_h)
+
+custom_env_template do
+  application application
+  deploy deploy
+  env environment_variables
+end

--- a/opsworks_custom_dot_env/templates/default/.env.erb
+++ b/opsworks_custom_dot_env/templates/default/.env.erb
@@ -1,0 +1,3 @@
+<% @env.sort.each do |key, val| %>
+  <%= key.to_s %>=<%= (val && val.to_s) %>
+<% end %>


### PR DESCRIPTION
This commit aligns the Chef 11.10 cookbook with the corresponding version for Chef 12.

cr https://code.amazon.com/reviews/CR-145844

Original commit: https://github.com/aws/opsworks-cookbooks/commit/8485b6fcc6c85dec3a0fa5ba458bbe1ecf0565e6